### PR TITLE
Automatically locating drive where R is mounted

### DIFF
--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -60,15 +60,26 @@ Function Bootstrap {
 
   Progress "Getting full path for R.vhd"
   $ImageFullPath = Get-ChildItem "..\R.vhd" | % { $_.FullName }
-  $ImageFullPath
+  $ImageSize = (Get-Item $ImageFullPath).length
+  echo "$ImageFullPath [$ImageSize bytes]"
 
   Progress "Mounting R.vhd"
   Mount-DiskImage -ImagePath $ImageFullPath
-  # Enumerating drive letters takes about 10 seconds:
-  # http://www.powershellmagazine.com/2013/03/07/pstip-finding-the-drive-letter-of-a-mounted-disk-image/
-  # Hard-coding mounted drive letter here
-  $ISOPath = "E:"
+
+  $drives=@("C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N"
+            "O", "P", "R", "S", "T", "U", "V", "W", "X", "Y", "Z")
+  foreach ($ISODrive in $drives) { 
+    $ISOPath = "${ISODrive}:"
+    if (Test-Path "${ISOPath}\R\bin" -PathType Container) {
+      break
+    }
+  }
+  # Assert that R was mounted properly
+  if ( -not (Test-Path "${ISOPath}\R\bin" -PathType Container) ) {
+    Throw "Failed to mount R. Could not find directory: <any drive letter>\R\bin"
+  }
   $RPath = $ISOPath
+  echo "R is now available on drive $RPath"
 
   Progress "Downloading and installing travis-tool.sh"
   Invoke-WebRequest http://raw.github.com/krlmlr/r-travis/master/scripts/travis-tool.sh -OutFile "..\travis-tool.sh"

--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -64,7 +64,7 @@ Function Bootstrap {
   echo "$ImageFullPath [$ImageSize bytes]"
 
   Progress "Mounting R.vhd"
-  $mountedISO = [string](Mount-DiskImage -ImagePath $ImageFullPath -Passthru) | Get-DiskImage | Get-Volume).DriveLetter + ":"
+  $mountedISO = [string](Mount-DiskImage -ImagePath $ImageFullPath -Passthru | Get-DiskImage | Get-Volume).DriveLetter + ":"
   echo "mountedISO=$mountedISO"
 
   $drives=@("C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N"

--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -64,7 +64,8 @@ Function Bootstrap {
   echo "$ImageFullPath [$ImageSize bytes]"
 
   Progress "Mounting R.vhd"
-  Mount-DiskImage -ImagePath $ImageFullPath
+  $mountedISO = [string](Mount-DiskImage -ImagePath $ImageFullPath -Passthru) | Get-DiskImage | Get-Volume).DriveLetter + ":"
+  echo "mountedISO=$mountedISO"
 
   $drives=@("C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N"
             "O", "P", "R", "S", "T", "U", "V", "W", "X", "Y", "Z")

--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -64,23 +64,12 @@ Function Bootstrap {
   echo "$ImageFullPath [$ImageSize bytes]"
 
   Progress "Mounting R.vhd"
-  $mountedISO = [string](Mount-DiskImage -ImagePath $ImageFullPath -Passthru | Get-DiskImage | Get-Disk | Get-Partition | Get-Volume).DriveLetter + ":"
-  echo "mountedISO=$mountedISO"
-
-  $drives=@("C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N"
-            "O", "P", "R", "S", "T", "U", "V", "W", "X", "Y", "Z")
-  foreach ($ISODrive in $drives) { 
-    $ISOPath = "${ISODrive}:"
-    if (Test-Path "${ISOPath}\R\bin" -PathType Container) {
-      break
-    }
-  }
+  $RDrive = [string](Mount-DiskImage -ImagePath $ImageFullPath -Passthru | Get-DiskImage | Get-Disk | Get-Partition | Get-Volume).DriveLetter + ":"
   # Assert that R was mounted properly
-  if ( -not (Test-Path "${ISOPath}\R\bin" -PathType Container) ) {
-    Throw "Failed to mount R. Could not find directory: <any drive letter>\R\bin"
+  if ( -not (Test-Path "${RDrive}\R\bin" -PathType Container) ) {
+    Throw "Failed to mount R. Could not find directory: ${RDrive}\R\bin"
   }
-  $RPath = $ISOPath
-  echo "R is now available on drive $RPath"
+  echo "R is now available on drive $RDrive"
 
   Progress "Downloading and installing travis-tool.sh"
   Invoke-WebRequest http://raw.github.com/krlmlr/r-travis/master/scripts/travis-tool.sh -OutFile "..\travis-tool.sh"
@@ -90,7 +79,7 @@ Function Bootstrap {
   cat .\.Rbuildignore
 
   Progress "Setting PATH"
-  $env:PATH = $ISOPath + '\Rtools\bin;' + $ISOPath + '\Rtools\MinGW\bin;' + $ISOPath + '\Rtools\gcc-4.6.3\bin;' + $RPath + '\R\bin\i386;' + $env:PATH
+  $env:PATH = $ISOPath + '\Rtools\bin;' + $ISOPath + '\Rtools\MinGW\bin;' + $ISOPath + '\Rtools\gcc-4.6.3\bin;' + $RDrive + '\R\bin\i386;' + $env:PATH
   $env:PATH.Split(";")
 
   Progress "Setting R_LIBS_USER"

--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -79,7 +79,7 @@ Function Bootstrap {
   cat .\.Rbuildignore
 
   Progress "Setting PATH"
-  $env:PATH = $ISOPath + '\Rtools\bin;' + $ISOPath + '\Rtools\MinGW\bin;' + $ISOPath + '\Rtools\gcc-4.6.3\bin;' + $RDrive + '\R\bin\i386;' + $env:PATH
+  $env:PATH = $RDrive + '\Rtools\bin;' + $RDrive + '\Rtools\MinGW\bin;' + $RDrive + '\Rtools\gcc-4.6.3\bin;' + $RDrive + '\R\bin\i386;' + $env:PATH
   $env:PATH.Split(";")
 
   Progress "Setting R_LIBS_USER"

--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -64,7 +64,7 @@ Function Bootstrap {
   echo "$ImageFullPath [$ImageSize bytes]"
 
   Progress "Mounting R.vhd"
-  $mountedISO = [string](Mount-DiskImage -ImagePath $ImageFullPath -Passthru | Get-DiskImage | Get-Volume).DriveLetter + ":"
+  $mountedISO = [string](Mount-DiskImage -ImagePath $ImageFullPath -Passthru | Get-DiskImage | Get-Disk | Get-Partition | Get-Volume).DriveLetter + ":"
   echo "mountedISO=$mountedISO"
 
   $drives=@("C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N"


### PR DESCRIPTION
This version quickly scans for where R was mounted, instead of assuming it's always on E:, which is the problem behind Issue #26.  Example output:
```
== 01/14/2015 19:23:15: Downloading R.vhd 
== 01/14/2015 19:23:55: Getting full path for R.vhd 
C:\projects\R.vhd [434966528 bytes]
== 01/14/2015 19:23:55: Mounting R.vhd 
R is now available on drive D:
== 01/14/2015 19:24:00: Downloading and installing travis-tool.sh 
```
Full example: https://ci.appveyor.com/project/HenrikBengtsson/r-appveyor/build/1.0.2