### PR TITLE
Create the R_LIBS_USER path only if it does not exist

### DIFF
--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -165,7 +165,9 @@ Function Bootstrap {
 
   Progress "Setting R_LIBS_USER"
   $env:R_LIBS_USER = 'c:\RLibrary'
-  mkdir $env:R_LIBS_USER
+  if ( -not(Test-Path $env:R_LIBS_USER) ) {
+    mkdir $env:R_LIBS_USER
+  }
 
   Progress "Bootstrap: Done"
 }


### PR DESCRIPTION
Currently you cannot cache the RLibrary directory because the mkdir fails (see https://ci.appveyor.com/project/jimhester/covr/build/1.0.49#L128). This should only create the directory if it does not already exist.