### PR TITLE
Rtools fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ These can be set in the `appveyor.yml`, overriding the defaults. [This repo](htt
 - `R_VERSION`: The version of R to be used for testing. Specify `devel`, `patched`, `stable` (or `release`), `oldrel`, or a version number.
 - `R_ARCH`: The architecture to be used for testing, one of `i386` (default) or `x64`.
 - `RTOOLS_VERSION`: The version of Rtools to be used for testing, defaults to the most recent Rtools. Specify e.g. `33` for Rtools 3.3.
+- `USE_RTOOLS`: Set `USE_RTOOLS: true` if Rtools needs to be installed, e.g. if you use install_github or if there are packages in Remotes: in your DESCRIPTION file. Defaults to `false`.
 - `GCC_PATH`: The path to GCC in the Rtools installation, currently one of `gcc-4.6.3` (default), `mingw_32` or `mingw_64`.
 - `WARNINGS_ARE_ERRORS`: Set to 1 to treat all warnings as errors.
 - `CRAN`: The CRAN mirror to use, defaults to [RStudio's CDN via HTTPS](https://cran.rstudio.com). Change to [HTTP](http://cran.rstudio.com) for R 3.1.3 or earlier.

--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -147,7 +147,7 @@ Function Bootstrap {
 
   InstallR
 
-  if ( Test-Path "src" ) {
+  if ((Test-Path 'src') -or ($env:USE_RTOOLS)) {
     InstallRtools
   }
   Else {

--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -147,7 +147,7 @@ Function Bootstrap {
 
   InstallR
 
-  if ((Test-Path 'src') -or ($env:USE_RTOOLS)) {
+  if ((Test-Path "src") -or ($env:USE_RTOOLS)) {
     InstallRtools
   }
   Else {


### PR DESCRIPTION
The goal was to implement @jimhester's idea for making it easier to install Rtools when using install_github or when having packages in the Remotes: part of the DESCRIPTION file.

Closes #55.