### PR TITLE
Add BINPREF environment variable

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,13 +18,16 @@ environment:
     WARNINGS_ARE_ERRORS: 1
 
   matrix:
-  - R_VERSION:
+  - R_VERSION: devel
 
-  - R_ARCH: x64
+  - R_VERSION: devel
+    R_ARCH: x64
 
-  - GCC_PATH: mingw_32
+  - R_VERSION: devel
+    GCC_PATH: mingw_32
 
-  - R_ARCH: x64
+  - R_VERSION: devel
+    R_ARCH: x64
     GCC_PATH: mingw_64
 
   - R_VERSION: release

--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -129,6 +129,7 @@ Function InstallRtools {
     $gcc_path = $env:GCC_PATH
   }
   $env:PATH = $RtoolsDrive + '\Rtools\bin;' + $RtoolsDrive + '\Rtools\MinGW\bin;' + $RtoolsDrive + '\Rtools\' + $gcc_path + '\bin;' + $env:PATH
+  $env:BINPREF=$RtoolsDrive + '/Rtools/mingw_$(WIN)/bin/'
 }
 
 Function Bootstrap {


### PR DESCRIPTION
This is needed to compile with the new toolchain and set the proper 32 or 64 bit compiler paths. It should be ignored using the old toolchain so setting it uniformly shouldn't be an issue.

https://ci.appveyor.com/project/jimhester/r-appveyor/build/1.0.7 has successfull builds

Fixes #61.