### PR TITLE
added msys as an operating system option

### DIFF
--- a/r-travis/scripts/travis-tool.sh
+++ b/r-travis/scripts/travis-tool.sh
@@ -276,7 +276,7 @@ DumpLogs() {
 
 RunTests() {
     echo "Building with: R CMD build ${R_BUILD_ARGS}"
-    if [[ "${OS:0:5}" == "MINGW" ]]; then
+    if [[ "${OS:0:5}" == "MINGW" || "${OS:0:4}" == "MSYS" ]]; then
         if [[ -d vignettes ]]; then
             rm -rf vignettes
             Rscript -e "d <- read.dcf('DESCRIPTION'); d[, colnames(d) == 'VignetteBuilder'] <- NA; write.dcf(d, 'DESCRIPTION')"
@@ -287,7 +287,7 @@ RunTests() {
     FILE=$(ls -1t *.tar.gz | head -n 1)
 
     # Create binary package (currently Windows only)
-    if [[ "${OS:0:5}" == "MINGW" ]]; then
+    if [[ "${OS:0:5}" == "MINGW" || "${OS:0:4}" == "MSYS" ]]; then
         R_CHECK_INSTALL_ARGS="--install-args=--build --no-multiarch"
     fi
 


### PR DESCRIPTION
I allowed for MSYS as an OS option for Windows.  This can happen if you manipulate the `PATH` variable.  I understand this isn't always recommended, but I wanted to make a build similar to an R setup with PS, RTools, Git, CMake installed with those bare requirements in the `PATH` (along with Appveyor utilities).

I can simply set
```
environment:
  global:
    R_CHECK_INSTALL_ARGS: "--install-args=--build --no-multiarch"
```

I see that you are working with `tic` (https://github.com/ropenscilabs/tic), and I'm not sure how this will work, but figured this may be a useful simple fix for Windows.

Example:
https://github.com/muschellij2/ITKR
and 
Appveyor: https://ci.appveyor.com/project/muschellij2/itkr/history