### PR TITLE
Allow users to override the pandoc version

### DIFF
--- a/r-travis/scripts/travis-tool.sh
+++ b/r-travis/scripts/travis-tool.sh
@@ -12,7 +12,7 @@ PKGTYPE=${PKGTYPE:-"both"}
 BIOC_USE_DEVEL=${BIOC_USE_DEVEL:-"TRUE"}
 OS=$(uname -s)
 
-PANDOC_VERSION='1.13.1'
+PANDOC_VERSION=${PANDOC_VERSION:-"1.19.2.1"}
 PANDOC_DIR="${HOME}/opt/pandoc"
 PANDOC_URL="https://s3.amazonaws.com/rstudio-buildtools/pandoc-${PANDOC_VERSION}.zip"
 


### PR DESCRIPTION
Also updated it to a more recent version.

I confirmed this version is available from that rstudio-buildtools directory.

Once we have this https://github.com/tidyverse/reprex/pull/145 should be fixed.

cc @jennybc