### PR TITLE
Run R CMD check in x64 by default

### DIFF
--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -53,7 +53,7 @@ Function InstallR {
   }
 
   if ( -not(Test-Path Env:\R_ARCH) ) {
-    $arch = "i386"
+    $arch = "x64"
   }
   Else {
     $arch = $env:R_ARCH


### PR DESCRIPTION
Runs R CMD check in 64bit by default, which is the native architecture on AppVeyor. This is a better default because the x64 binaries can also check 32bit but not always vice versa.

For example this fixes a [false positive](https://ci.appveyor.com/project/tidyverse/glue) note that we often see like below:

```
File 'glue/libs/x64/glue.dll':
  Found no calls to: 'R_registerRoutines', 'R_useDynamicSymbols'
It is good practice to register native routines and to disable symbol
search.
```

This happens because the 32bit toolchain cannot check the symbols from the 64bit dll.

