### PR TITLE
Update deprecated devtools::use_appveyor() calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Usage
 
 1. Sign up to [AppVeyor](http://appveyor.com).
 2. [Enable testing](https://ci.appveyor.com/projects/new) for your project.
-3. Run `devtools::use_appveyor()` in your project.
+3. Run `usethis::use_appveyor()` in your project.
 4. (Optional) Adapt `appveyor.yml` to your needs according to the [documentation](http://www.appveyor.com/docs/appveyor-yml).
-5. (Optional) Add a badge as described by the output of `devtools::use_appveyor()`.
+5. (Optional) Add a badge as described by the output of `usethis::use_appveyor()`.
 6. Be sure to supply a `.gitattributes` file that takes care of fixing CRLF conversion settings that are relevant on Windows.  [The one in this repo](/.gitattributes) can be used for starters.
 7. Push to your repo to start building.
 8. Enjoy!


### PR DESCRIPTION
It seems that `devtools::use_appveyor` has been deprecated in favor of `usethis::use_appveyor`.

    > devtools::use_appveyor()
    Warning message:
    'devtools::use_appveyor' is deprecated.
    Use 'usethis::use_appveyor()' instead.
    See help("Deprecated") and help("devtools-deprecated"). 

This commit updates the REAMDE.md file to reflect this fact.