### PR TITLE
Download GitHub scripts from raw.githubusercontent.com

### DIFF
--- a/r-travis/sample.travis.yml
+++ b/r-travis/sample.travis.yml
@@ -7,7 +7,7 @@
 language: c
 
 before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+  - curl -OL http://raw.githubusercontent.com/craigcitro/r-travis/master/scripts/travis-tool.sh
   - chmod 755 ./travis-tool.sh
   - ./travis-tool.sh bootstrap
 install:

--- a/r-travis/sample_revdeps.travis.yml
+++ b/r-travis/sample_revdeps.travis.yml
@@ -25,7 +25,7 @@ matrix:
 
 
 before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+  - curl -OL http://raw.githubusercontent.com/craigcitro/r-travis/master/scripts/travis-tool.sh
   - chmod 755 ./travis-tool.sh
   - ./travis-tool.sh bootstrap
 install:

--- a/sample.appveyor.yml
+++ b/sample.appveyor.yml
@@ -4,7 +4,7 @@
 init:
   ps: |
         $ErrorActionPreference = "Stop"
-        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Invoke-WebRequest http://raw.githubusercontent.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
         Import-Module '..\appveyor-tool.ps1'
 
 install:

--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -166,7 +166,7 @@ Function Bootstrap {
   }
 
   Progress "Downloading and installing travis-tool.sh"
-  Invoke-WebRequest https://raw.github.com/krlmlr/r-appveyor/master/r-travis/scripts/travis-tool.sh -OutFile "..\travis-tool.sh"
+  Invoke-WebRequest https://raw.githubusercontent.com/krlmlr/r-appveyor/master/r-travis/scripts/travis-tool.sh -OutFile "..\travis-tool.sh"
   echo '@bash.exe ../travis-tool.sh %*' | Out-File -Encoding ASCII .\travis-tool.sh.cmd
   cat .\travis-tool.sh.cmd
   bash -c "echo '^travis-tool\.sh\.cmd$' >> .Rbuildignore"


### PR DESCRIPTION
My AppVeyor builds are failing today because they can't download files from the raw.github.com host. According to this [GitHub announcement](https://developer.github.com/changes/2014-04-25-user-content-security/), they should be redirected to raw.githubusercontent.com.

I manually changed the URL in my appveyor.yml file for my package, but then appveyor-tool.ps1 fails when it tries to download travis-tool.sh:

https://github.com/krlmlr/r-appveyor/blob/8d3f394fb0da7e84c962ffc20d16cb47d050adfd/scripts/appveyor-tool.ps1#L169

This PR updates all the URLs from raw.github.com to raw.githubusercontent.com since the latter is currently accessible (and presumably more stable since it doesn't involve redirection):

```
RCurl::url.exists("https://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1")
## [1] FALSE
RCurl::url.exists("https://raw.githubusercontent.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1")
## [1] TRUE
```


I couldn't find any past discussion on the choice of URL ([search](https://github.com/krlmlr/r-appveyor/search?q=raw.github&type=Issues))