### PR TITLE
use default CRAN repo, closes #139

### DIFF
--- a/r-travis/scripts/travis-tool.sh
+++ b/r-travis/scripts/travis-tool.sh
@@ -35,7 +35,7 @@ R_USE_BIOC_INST="source('${BIOC}');"\
 " options(repos=biocinstallRepos())"
 
 R_USE_BIOC_MNGR="if (!requireNamespace('BiocManager', quietly=TRUE))"\
-" install.packages('BiocManager');"\
+" install.packages('BiocManager', repos=c(CRAN='${CRAN}'));"\
 " if (${BIOC_USE_DEVEL})"\
 " BiocManager::install(version = 'devel');"\
 " options(repos=BiocManager::repositories())"


### PR DESCRIPTION
This should fix the issue where there is no default `CRAN` repository. 
The rest of the code seems to use this repo as default. 

Thanks,
MR