### PR TITLE
ENH: added WARNINGS_ARE_ERRORS=1 by default

### DIFF
--- a/r-travis/scripts/travis-tool.sh
+++ b/r-travis/scripts/travis-tool.sh
@@ -11,6 +11,7 @@ BIOC=${BIOC:-"http://bioconductor.org/biocLite.R"}
 PKGTYPE=${PKGTYPE:-"both"}
 BIOC_USE_DEVEL=${BIOC_USE_DEVEL:-"TRUE"}
 OS=$(uname -s)
+WARNINGS_ARE_ERRORS=1
 
 PANDOC_VERSION='1.13.1'
 PANDOC_DIR="${HOME}/opt/pandoc"


### PR DESCRIPTION
Trying to harmonize with travis defaults: https://docs.travis-ci.com/user/languages/r/#package-check-options, alongside https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/r.rb#L13, so that warnings are treated as errors by default.  

This is potentially breaking behavior and also not "easy" for most users if they don't know how to set global variables or unset.