### PR TITLE
set R_REMOTES_STANDALONE=true

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ install:
 
 environment:
   global:
+    R_REMOTES_STANDALONE: true
     WARNINGS_ARE_ERRORS: 1
 
   matrix:


### PR DESCRIPTION
People might copy `appveyor.yml` for their personal use and setting `R_REMOTES_STANDALONE=true` might prevent quite some problems related to _curl_ on appveyor

#135 

See also https://github.com/ropenscilabs/tic/pull/178