### PR TITLE
Fix legacy toolchain for after R 4.0

### DIFF
--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -133,8 +133,7 @@ Function InstallRtools40 {
 
 Function InstallRtools {
   if ( -not(Test-Path Env:\RTOOLS_VERSION) ) {
-    Progress "Determining Rtools version"
-    $rtoolsver = $(Invoke-WebRequest ($CRAN + "/bin/windows/Rtools/VERSION.txt")).Content.Split(' ')[2].Split('.')[0..1] -Join ''
+    $rtoolsver = '35'
   }
   Else {
     $rtoolsver = $env:RTOOLS_VERSION


### PR DESCRIPTION
I realized there is a bug here.

After next week, the online `VERSION.txt` will contain `4.0` so it is no longer compatible with 3.x. So instead we use the latest 3x compatible version (Rtools35)