### PR TITLE
Use version-specific package library

### DIFF
--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -198,7 +198,7 @@ Function Bootstrap {
   $env:PATH.Split(";")
 
   Progress "Setting R_LIBS_USER"
-  $env:R_LIBS_USER = 'c:\RLibrary'
+  $env:R_LIBS_USER = 'c:\RLibrary\' + $rversion.Substring(0,3)
   if ( -not(Test-Path $env:R_LIBS_USER) ) {
     mkdir $env:R_LIBS_USER
   }


### PR DESCRIPTION
A lot of people are currently seeing this [(example here)](https://ci.appveyor.com/project/mdsumner/proj-448mq/builds/32441222#L181)

```
Installing dependencies
+ Rscript -e 'options(repos = c(CRAN = "https://cloud.r-project.org"), download.file.method = "auto"); remotes::install_deps(dependencies = TRUE, type="win.binary")'
Error: package 'remotes' was installed before R 4.0.0: please re-install it
Execution halted
Command exited with code 1
```

The problem is that they have cached the package library, but it is outdated. The solution is to flush the cache but many people don't know this.

The following versions the package library using the major part of the version, in the same way as R itself does when we do not set R_LIB_USER.

