### PR TITLE
Use https://api.r-hub.io/rversions/ instead

### DIFF
--- a/scripts/appveyor-tool.ps1
+++ b/scripts/appveyor-tool.ps1
@@ -80,17 +80,17 @@ Function InstallR {
   }
   ElseIf (($version -eq "stable") -or ($version -eq "release")) {
     $url_path = ""
-    $version = $(ConvertFrom-JSON $(Invoke-WebRequest http://rversions.r-pkg.org/r-release-win).Content).version
+    $version = $(ConvertFrom-JSON $(Invoke-WebRequest https://api.r-hub.io/rversions/r-release-win).Content).version
     If ($version -eq "3.2.4") {
       $version = "3.2.4revised"
     }
   }
   ElseIf ($version -eq "patched") {
     $url_path = ""
-    $version = $(ConvertFrom-JSON $(Invoke-WebRequest http://rversions.r-pkg.org/r-release-win).Content).version + "patched"
+    $version = $(ConvertFrom-JSON $(Invoke-WebRequest https://api.r-hub.io/rversions/r-release-win).Content).version + "patched"
   }
   ElseIf ($version -eq "oldrel") {
-    $version = $(ConvertFrom-JSON $(Invoke-WebRequest http://rversions.r-pkg.org/r-oldrel).Content).version
+    $version = $(ConvertFrom-JSON $(Invoke-WebRequest https://api.r-hub.io/rversions/r-oldrel).Content).version
     $url_path = ("old/" + $version + "/")
   }
   Else {


### PR DESCRIPTION
Because the R versions from https://rversions.r-pkg.org are manually updated by @gaborcsardi.